### PR TITLE
Add to "pbs.disk.status" new value - "passed"

### DIFF
--- a/template_app_proxmox_backup_server.yaml
+++ b/template_app_proxmox_backup_server.yaml
@@ -503,7 +503,10 @@ zabbix_export:
                 key: pbs.disks
               trigger_prototypes:
                 - uuid: 0ebb109edcbc40d095945ca9a530dc5f
-                  expression: 'find(/Proxmox Backup Server by HTTP/pbs.disk.status[{#DISK.PATH}],,"like","unknown")=0'
+                  expression: |
+                    find(/Proxmox Backup Server by HTTP/pbs.disk.status[{#DISK.PATH}],,"like","unknown")=0
+                    or
+                    find(/Proxmox Backup Server by HTTP/pbs.disk.status[{#DISK.PATH}],,"like","passed")=0
                   name: 'PBS: Disk [{#DISK.PATH}] Status indicates a problem'
                   priority: WARNING
                   manual_close: 'YES'


### PR DESCRIPTION
Hi, thanks for the template!

In my case the disk status is `passed`, but zabbix thinks it's a problem, so I updated the expression a little bit to fix it.